### PR TITLE
Fix parametric option typo

### DIFF
--- a/R/jjbetweenstats.h.R
+++ b/R/jjbetweenstats.h.R
@@ -10,7 +10,7 @@ jjbetweenstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             group = NULL,
             grvar = NULL,
             centralityplotting = FALSE,
-            centralitytype = "parameteric",
+            centralitytype = "parametric",
             typestatistics = "parametric",
             pairwisecomparisons = FALSE,
             pairwisedisplay = "significant",
@@ -63,11 +63,11 @@ jjbetweenstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
                 "centralitytype",
                 centralitytype,
                 options=list(
-                    "parameteric",
+                    "parametric",
                     "nonparametric",
                     "robust",
                     "bayes"),
-                default="parameteric")
+                default="parametric")
             private$..typestatistics <- jmvcore::OptionList$new(
                 "typestatistics",
                 typestatistics,
@@ -308,7 +308,7 @@ jjbetweenstats <- function(
     group,
     grvar = NULL,
     centralityplotting = FALSE,
-    centralitytype = "parameteric",
+    centralitytype = "parametric",
     typestatistics = "parametric",
     pairwisecomparisons = FALSE,
     pairwisedisplay = "significant",

--- a/R/jjdotplotstats.h.R
+++ b/R/jjdotplotstats.h.R
@@ -12,7 +12,7 @@ jjdotplotstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
             typestatistics = "parametric",
             effsizetype = "biased",
             centralityplotting = FALSE,
-            centralitytype = "parameteric",
+            centralitytype = "parametric",
             mytitle = "",
             xtitle = "",
             ytitle = "",
@@ -74,11 +74,11 @@ jjdotplotstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cl
                 "centralitytype",
                 centralitytype,
                 options=list(
-                    "parameteric",
+                    "parametric",
                     "nonparametric",
                     "robust",
                     "bayes"),
-                default="parameteric")
+                default="parametric")
             private$..mytitle <- jmvcore::OptionString$new(
                 "mytitle",
                 mytitle,
@@ -246,7 +246,7 @@ jjdotplotstats <- function(
     typestatistics = "parametric",
     effsizetype = "biased",
     centralityplotting = FALSE,
-    centralitytype = "parameteric",
+    centralitytype = "parametric",
     mytitle = "",
     xtitle = "",
     ytitle = "",

--- a/R/jjwithinstats.h.R
+++ b/R/jjwithinstats.h.R
@@ -13,7 +13,7 @@ jjwithinstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cla
             pointpath = FALSE,
             centralitypath = FALSE,
             centralityplotting = FALSE,
-            centralitytype = "parameteric",
+            centralitytype = "parametric",
             typestatistics = "parametric",
             pairwisecomparisons = FALSE,
             pairwisedisplay = "significant",
@@ -78,11 +78,11 @@ jjwithinstatsOptions <- if (requireNamespace("jmvcore", quietly=TRUE)) R6::R6Cla
                 "centralitytype",
                 centralitytype,
                 options=list(
-                    "parameteric",
+                    "parametric",
                     "nonparametric",
                     "robust",
                     "bayes"),
-                default="parameteric")
+                default="parametric")
             private$..typestatistics <- jmvcore::OptionList$new(
                 "typestatistics",
                 typestatistics,
@@ -330,7 +330,7 @@ jjwithinstats <- function(
     pointpath = FALSE,
     centralitypath = FALSE,
     centralityplotting = FALSE,
-    centralitytype = "parameteric",
+    centralitytype = "parametric",
     typestatistics = "parametric",
     pairwisecomparisons = FALSE,
     pairwisedisplay = "significant",

--- a/jamovi/jjbetweenstats.a.yaml
+++ b/jamovi/jjbetweenstats.a.yaml
@@ -54,15 +54,15 @@ options:
       title: 'Centrality Type'
       type: List
       options:
-        - title: mean (parameteric)
-          name: parameteric
+        - title: mean (parametric)
+          name: parametric
         - title: median (nonparametric)
           name: nonparametric
         - title: robust (trimmed mean)
           name: robust
         - title: bayes (MAP estimator)
           name: bayes 
-      default: parameteric
+      default: parametric
 
 
     - name: typestatistics

--- a/jamovi/jjdotplotstats.a.yaml
+++ b/jamovi/jjdotplotstats.a.yaml
@@ -84,15 +84,15 @@ options:
       title: 'Centrality Type'
       type: List
       options:
-        - title: mean (parameteric)
-          name: parameteric
+        - title: mean (parametric)
+          name: parametric
         - title: median (nonparametric)
           name: nonparametric
         - title: robust (trimmed mean)
           name: robust
         - title: bayes (MAP estimator)
           name: bayes 
-      default: parameteric
+      default: parametric
 
     - name: mytitle
       title: Title

--- a/jamovi/jjwithinstats.a.yaml
+++ b/jamovi/jjwithinstats.a.yaml
@@ -69,15 +69,15 @@ options:
       title: 'Centrality Type'
       type: List
       options:
-        - title: mean (parameteric)
-          name: parameteric
+        - title: mean (parametric)
+          name: parametric
         - title: median (nonparametric)
           name: nonparametric
         - title: robust (trimmed mean)
           name: robust
         - title: bayes (MAP estimator)
           name: bayes 
-      default: parameteric
+      default: parametric
 
 
     - name: typestatistics

--- a/man/jjbetweenstats.Rd
+++ b/man/jjbetweenstats.Rd
@@ -10,7 +10,7 @@ jjbetweenstats(
   group,
   grvar = NULL,
   centralityplotting = FALSE,
-  centralitytype = "parameteric",
+  centralitytype = "parametric",
   typestatistics = "parametric",
   pairwisecomparisons = FALSE,
   pairwisedisplay = "significant",

--- a/man/jjdotplotstats.Rd
+++ b/man/jjdotplotstats.Rd
@@ -12,7 +12,7 @@ jjdotplotstats(
   typestatistics = "parametric",
   effsizetype = "biased",
   centralityplotting = FALSE,
-  centralitytype = "parameteric",
+  centralitytype = "parametric",
   mytitle = "",
   xtitle = "",
   ytitle = "",

--- a/man/jjwithinstats.Rd
+++ b/man/jjwithinstats.Rd
@@ -13,7 +13,7 @@ jjwithinstats(
   pointpath = FALSE,
   centralitypath = FALSE,
   centralityplotting = FALSE,
-  centralitytype = "parameteric",
+  centralitytype = "parametric",
   typestatistics = "parametric",
   pairwisecomparisons = FALSE,
   pairwisedisplay = "significant",


### PR DESCRIPTION
## Summary
- correct the misspelled `parameteric` option across YAML, R sources, and man pages
- update generated documentation

## Testing
- `R` was not available so no automated tests could be run